### PR TITLE
[Refactor] 회원가입 예외 http상태 코드 변경 

### DIFF
--- a/src/main/java/com/example/yanolja/domain/user/controller/UserControllerAdvice.java
+++ b/src/main/java/com/example/yanolja/domain/user/controller/UserControllerAdvice.java
@@ -29,8 +29,8 @@ public class UserControllerAdvice {
     public ResponseEntity<ResponseDTO<Object>> handleInvalidEmailException(
         InvalidEmailException exception
     ) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
-            ResponseDTO.res(HttpStatus.BAD_REQUEST,
+        return ResponseEntity.status(HttpStatus.PRECONDITION_FAILED).body(
+            ResponseDTO.res(HttpStatus.PRECONDITION_FAILED,
                 exception.getMessage()));
     }
 
@@ -40,8 +40,8 @@ public class UserControllerAdvice {
     public ResponseEntity<ResponseDTO<Object>> handlePhonenumberException(
         InvalidPhonenumberError exception
     ) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
-            ResponseDTO.res(HttpStatus.BAD_REQUEST,
+        return ResponseEntity.status(HttpStatus.LENGTH_REQUIRED).body(
+            ResponseDTO.res(HttpStatus.LENGTH_REQUIRED,
                 exception.getMessage()));
     }
 }

--- a/src/main/java/com/example/yanolja/domain/user/controller/UserControllerAdvice.java
+++ b/src/main/java/com/example/yanolja/domain/user/controller/UserControllerAdvice.java
@@ -3,6 +3,7 @@ package com.example.yanolja.domain.user.controller;
 import com.example.yanolja.domain.user.exception.EmailDuplicateError;
 import com.example.yanolja.domain.user.exception.InvalidEmailException;
 import com.example.yanolja.domain.user.exception.InvalidPhonenumberError;
+import com.example.yanolja.domain.user.exception.UserNotFoundException;
 import com.example.yanolja.global.util.ResponseDTO;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -44,4 +45,15 @@ public class UserControllerAdvice {
             ResponseDTO.res(HttpStatus.LENGTH_REQUIRED,
                 exception.getMessage()));
     }
+
+    @ExceptionHandler(value = {
+        UserNotFoundException.class
+    })
+    public ResponseEntity<ResponseDTO<Object>> handleUserNotFoundException(
+        UserNotFoundException exception
+    ) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+            ResponseDTO.res(HttpStatus.NOT_FOUND, exception.getMessage()));
+    }
 }
+

--- a/src/main/java/com/example/yanolja/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/example/yanolja/domain/user/exception/UserNotFoundException.java
@@ -7,6 +7,6 @@ import com.example.yanolja.global.exception.ErrorCode;
 public class UserNotFoundException extends ApplicationException {
 
     public UserNotFoundException(String message) {
-        super(ErrorCode.MEMBER_NOT_FOUND, message);
+        super(ErrorCode.USER_NOT_FOUND, message);
     }
 }

--- a/src/main/java/com/example/yanolja/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/yanolja/global/exception/ErrorCode.java
@@ -7,12 +7,11 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // USER
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
     USER_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "이미 가입된 회원입니다."),
-    DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임 입니다."),
-    REGISTRATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "회원가입 실패"),
-    INVALID_PHONENUMBER(HttpStatus.BAD_REQUEST, "유효하지 않은 휴대폰 번호 형식"),
-    INVALID_EMAIL(HttpStatus.BAD_REQUEST, "유효하지 이메일 형식"),
+    INVALID_PHONENUMBER(HttpStatus.LENGTH_REQUIRED, "유효하지 않은 휴대폰 번호 형식"),
+    INVALID_EMAIL(HttpStatus.PRECONDITION_FAILED, "유효하지 않은 이메일 형식"),
+
     //Reservation
     INVALID_ACCOMMODATION_ID(HttpStatus.BAD_REQUEST, "존재하지 않는 방입니다."),
     //Basket

--- a/src/main/java/com/example/yanolja/global/exception/ErrorMessage.java
+++ b/src/main/java/com/example/yanolja/global/exception/ErrorMessage.java
@@ -1,7 +1,0 @@
-package com.example.yanolja.global.exception;
-
-import java.time.LocalDateTime;
-
-public record ErrorMessage(String message, LocalDateTime timestamp) {
-
-}


### PR DESCRIPTION
## ⭐ [Refactor] 회원가입 예외 http상태 코드 변경 

### ErrorMessage.java 삭제
- ErrorCode클래스를 추가해 ErrorMessage클래스 불필요 -> 삭제

### 회원가입 예외 http상태 코드 변경
문제 사항:
 - 프론트측에서 예외별로 http상태 코드를 구별해줄 것을 요청받음.
 
변경 사항 :
 - 400-> "이미 가입된 회원입니다."
 ![image](https://github.com/TeamOHJO/yanoljaProject-Backend/assets/105612931/022ae906-b437-4c67-ae49-e1dde0ae87a0)
 -  411-> "유효하지 않은 휴대폰 번호 형식"
 ![image](https://github.com/TeamOHJO/yanoljaProject-Backend/assets/105612931/851d6320-1cb3-4e90-aafe-d27ccd5720a2)
- 412-> "유효하지 않은 이메일 형식"
![image](https://github.com/TeamOHJO/yanoljaProject-Backend/assets/105612931/bb816d66-75d4-4197-8948-45cae6d62a72)

### UserNotFoundException핸들러 추가
문제 사항:
 - UserControllerAdvice에 UserNotFoundException 누락

변경 사항 :
 - UserNotFoundException핸들러 메서드 추가

### #️⃣ Issue Link - #10 

