### PR TITLE
[Feature] 사용자 정보조회, 정보수정 기능 구현

### DIFF
--- a/src/main/java/com/example/yanolja/domain/user/controller/EmailController.java
+++ b/src/main/java/com/example/yanolja/domain/user/controller/EmailController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
-import com.example.yanolja.domain.user.request.EmailRequest;
+import com.example.yanolja.domain.user.dto.EmailRequest;
 import com.example.yanolja.domain.user.service.EmailService;
 
 @RestController

--- a/src/main/java/com/example/yanolja/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/yanolja/domain/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.example.yanolja.domain.user.controller;
 
 import com.example.yanolja.domain.user.dto.CreateUserRequest;
 import com.example.yanolja.domain.user.dto.CreateUserResponse;
+import com.example.yanolja.domain.user.dto.UpdateUserRequest;
 import com.example.yanolja.domain.user.entity.User;
 import com.example.yanolja.domain.user.service.UserService;
 import com.example.yanolja.global.springsecurity.PrincipalDetails;
@@ -14,6 +15,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -47,6 +49,15 @@ public class UserController {
         ResponseDTO<CreateUserResponse> response = ResponseDTO.res(
             HttpStatus.OK, "사용자 정보 조회 성공", userInfo);
         return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/update")
+    public ResponseEntity<ResponseDTO<?>> updateUserInfo(
+        @AuthenticationPrincipal PrincipalDetails principalDetails,
+        @RequestBody UpdateUserRequest updateUserRequest) {
+
+        ResponseDTO<?> response = userService.updateUser(principalDetails.getUser().getId(), updateUserRequest);
+        return ResponseEntity.status(response.getCode()).body(response);
     }
 
     // Authenticated user 샘플테스트 코드입니다

--- a/src/main/java/com/example/yanolja/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/yanolja/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.example.yanolja.domain.user.controller;
 
+import com.example.yanolja.domain.user.dto.ChangePasswordRequest;
 import com.example.yanolja.domain.user.dto.CreateUserRequest;
 import com.example.yanolja.domain.user.dto.CreateUserResponse;
 import com.example.yanolja.domain.user.dto.UpdateUserRequest;
@@ -57,6 +58,15 @@ public class UserController {
         @RequestBody UpdateUserRequest updateUserRequest) {
 
         ResponseDTO<?> response = userService.updateUser(principalDetails.getUser().getId(), updateUserRequest);
+        return ResponseEntity.status(response.getCode()).body(response);
+    }
+
+    @PutMapping("/repassword")
+    public ResponseEntity<ResponseDTO<?>> changePassword(
+        @AuthenticationPrincipal PrincipalDetails principalDetails,
+        @RequestBody ChangePasswordRequest changePasswordRequest) {
+
+        ResponseDTO<?> response = userService.changePassword(principalDetails.getUser().getId(), changePasswordRequest);
         return ResponseEntity.status(response.getCode()).body(response);
     }
 

--- a/src/main/java/com/example/yanolja/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/yanolja/domain/user/controller/UserController.java
@@ -8,6 +8,7 @@ import com.example.yanolja.global.springsecurity.PrincipalDetails;
 import com.example.yanolja.global.util.ResponseDTO;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -36,6 +37,16 @@ public class UserController {
         @AuthenticationPrincipal PrincipalDetails principalDetails) {
         ResponseDTO<?> response = userService.deleteUser(principalDetails.getUser().getId());
         return ResponseEntity.status(response.getCode()).body(response);
+    }
+
+    @GetMapping("/mypage")
+    public ResponseEntity<ResponseDTO<CreateUserResponse>> getMyPageInfo(
+        @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        User user = principalDetails.getUser();
+        CreateUserResponse userInfo = CreateUserResponse.fromEntity(user);
+        ResponseDTO<CreateUserResponse> response = ResponseDTO.res(
+            HttpStatus.OK, "사용자 정보 조회 성공", userInfo);
+        return ResponseEntity.ok(response);
     }
 
     // Authenticated user 샘플테스트 코드입니다

--- a/src/main/java/com/example/yanolja/domain/user/controller/UserControllerAdvice.java
+++ b/src/main/java/com/example/yanolja/domain/user/controller/UserControllerAdvice.java
@@ -2,6 +2,7 @@ package com.example.yanolja.domain.user.controller;
 
 import com.example.yanolja.domain.user.exception.EmailDuplicateError;
 import com.example.yanolja.domain.user.exception.InvalidEmailException;
+import com.example.yanolja.domain.user.exception.InvalidPasswordException;
 import com.example.yanolja.domain.user.exception.InvalidPhonenumberError;
 import com.example.yanolja.domain.user.exception.UserNotFoundException;
 import com.example.yanolja.global.util.ResponseDTO;
@@ -55,5 +56,15 @@ public class UserControllerAdvice {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
             ResponseDTO.res(HttpStatus.NOT_FOUND, exception.getMessage()));
     }
+
+    @ExceptionHandler(value = InvalidPasswordException.class)
+    public ResponseEntity<ResponseDTO<Object>> handleInvalidPasswordException(
+        InvalidPasswordException exception) {
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ResponseDTO.res(HttpStatus.BAD_REQUEST, exception.getMessage()));
+    }
+
+
 }
 

--- a/src/main/java/com/example/yanolja/domain/user/dto/ChangePasswordRequest.java
+++ b/src/main/java/com/example/yanolja/domain/user/dto/ChangePasswordRequest.java
@@ -1,0 +1,17 @@
+package com.example.yanolja.domain.user.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+
+@Data
+public class ChangePasswordRequest {
+
+    @NotNull
+    private String oldPassword;
+
+    @NotNull
+    private String newPassword;
+
+
+}

--- a/src/main/java/com/example/yanolja/domain/user/dto/EmailRequest.java
+++ b/src/main/java/com/example/yanolja/domain/user/dto/EmailRequest.java
@@ -1,4 +1,4 @@
-package com.example.yanolja.domain.user.request;
+package com.example.yanolja.domain.user.dto;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/example/yanolja/domain/user/dto/UpdateUserRequest.java
+++ b/src/main/java/com/example/yanolja/domain/user/dto/UpdateUserRequest.java
@@ -1,0 +1,27 @@
+package com.example.yanolja.domain.user.dto;
+import com.example.yanolja.domain.user.entity.User;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+@Data
+public class UpdateUserRequest {
+    @NotNull
+    private String username;
+
+    @NotNull
+    private String password;
+
+    @NotNull
+    private String phonenumber;
+
+
+
+    public User toEntity(User user) {
+        BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+        user.setUsername(this.username);
+        user.setPassword(passwordEncoder.encode(this.password));
+        user.setPhonenumber(this.phonenumber);
+        return user;
+    }
+
+}

--- a/src/main/java/com/example/yanolja/domain/user/dto/UpdateUserRequest.java
+++ b/src/main/java/com/example/yanolja/domain/user/dto/UpdateUserRequest.java
@@ -2,24 +2,17 @@ package com.example.yanolja.domain.user.dto;
 import com.example.yanolja.domain.user.entity.User;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
 @Data
 public class UpdateUserRequest {
     @NotNull
     private String username;
 
     @NotNull
-    private String password;
-
-    @NotNull
     private String phonenumber;
 
-
-
     public User toEntity(User user) {
-        BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
         user.setUsername(this.username);
-        user.setPassword(passwordEncoder.encode(this.password));
         user.setPhonenumber(this.phonenumber);
         return user;
     }

--- a/src/main/java/com/example/yanolja/domain/user/entity/User.java
+++ b/src/main/java/com/example/yanolja/domain/user/entity/User.java
@@ -57,4 +57,17 @@ public class User extends BaseTimeEntity {
 
     private String authority;
 
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public void setPhonenumber(String phonenumber) {
+        this.phonenumber = phonenumber;
+    }
+
+
 }

--- a/src/main/java/com/example/yanolja/domain/user/exception/InvalidPasswordException.java
+++ b/src/main/java/com/example/yanolja/domain/user/exception/InvalidPasswordException.java
@@ -1,0 +1,13 @@
+package com.example.yanolja.domain.user.exception;
+
+import com.example.yanolja.global.exception.ApplicationException;
+import com.example.yanolja.global.exception.ErrorCode;
+
+public class InvalidPasswordException extends ApplicationException {
+
+    public InvalidPasswordException(ErrorCode errorCode) {
+
+        super(errorCode);
+    }
+
+}

--- a/src/main/java/com/example/yanolja/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/example/yanolja/domain/user/exception/UserNotFoundException.java
@@ -6,7 +6,8 @@ import com.example.yanolja.global.exception.ErrorCode;
 
 public class UserNotFoundException extends ApplicationException {
 
-    public UserNotFoundException(String message) {
-        super(ErrorCode.USER_NOT_FOUND, message);
+    public UserNotFoundException(ErrorCode errorCode) {
+
+        super(errorCode);
     }
 }

--- a/src/main/java/com/example/yanolja/domain/user/service/UserService.java
+++ b/src/main/java/com/example/yanolja/domain/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.example.yanolja.domain.user.service;
 
 
 import com.example.yanolja.domain.user.dto.CreateUserRequest;
+import com.example.yanolja.domain.user.dto.UpdateUserRequest;
 import com.example.yanolja.global.util.ResponseDTO;
 
 public interface UserService {
@@ -9,5 +10,7 @@ public interface UserService {
     ResponseDTO<?> signup(CreateUserRequest createUserRequest);
 
     ResponseDTO<?> deleteUser(Long userId);
+
+    ResponseDTO<?> updateUser(Long userId, UpdateUserRequest updateUserRequest);
 
 }

--- a/src/main/java/com/example/yanolja/domain/user/service/UserService.java
+++ b/src/main/java/com/example/yanolja/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.example.yanolja.domain.user.service;
 
 
+import com.example.yanolja.domain.user.dto.ChangePasswordRequest;
 import com.example.yanolja.domain.user.dto.CreateUserRequest;
 import com.example.yanolja.domain.user.dto.UpdateUserRequest;
 import com.example.yanolja.global.util.ResponseDTO;
@@ -12,5 +13,7 @@ public interface UserService {
     ResponseDTO<?> deleteUser(Long userId);
 
     ResponseDTO<?> updateUser(Long userId, UpdateUserRequest updateUserRequest);
+
+    ResponseDTO<?> changePassword(Long userId, ChangePasswordRequest changePasswordRequest);
 
 }

--- a/src/main/java/com/example/yanolja/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/yanolja/domain/user/service/UserServiceImpl.java
@@ -6,6 +6,7 @@ import static com.example.yanolja.global.exception.ErrorCode.USER_ALREADY_REGIST
 
 import com.example.yanolja.domain.user.dto.CreateUserRequest;
 import com.example.yanolja.domain.user.dto.CreateUserResponse;
+import com.example.yanolja.domain.user.dto.UpdateUserRequest;
 import com.example.yanolja.domain.user.entity.User;
 import com.example.yanolja.domain.user.exception.EmailDuplicateError;
 import com.example.yanolja.domain.user.exception.InvalidEmailException;
@@ -91,6 +92,17 @@ public class UserServiceImpl implements UserService {
         } catch (Exception e) {
             return ResponseDTO.res(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러: " + e.getMessage());
         }
+    }
+
+    @Override
+    public ResponseDTO<?> updateUser(Long userId, UpdateUserRequest updateUserRequest) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다.")); // 적절한 예외 처리 필요
+
+        updateUserRequest.toEntity(user);
+        userRepository.save(user);
+
+        return ResponseDTO.res(HttpStatus.OK, "사용자 정보 업데이트 성공");
     }
 
 

--- a/src/main/java/com/example/yanolja/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/yanolja/domain/user/service/UserServiceImpl.java
@@ -106,11 +106,28 @@ public class UserServiceImpl implements UserService {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
 
-        updateUserRequest.toEntity(user);
-        userRepository.save(user);
+        if (!isValidPhonenumber(updateUserRequest.getPhonenumber())) {
+            throw new InvalidPhonenumberError(INVALID_PHONENUMBER);
+        }
+
+        boolean isUpdated = false;
+        if (!user.getUsername().equals(updateUserRequest.getUsername())) {
+            user.setUsername(updateUserRequest.getUsername());
+            isUpdated = true;
+        }
+
+        if (!user.getPhonenumber().equals(updateUserRequest.getPhonenumber())) {
+            user.setPhonenumber(updateUserRequest.getPhonenumber());
+            isUpdated = true;
+        }
+
+        if (isUpdated) {
+            userRepository.save(user);
+        }
 
         return ResponseDTO.res(HttpStatus.OK, "사용자 정보 업데이트 성공");
     }
+
 
     @Override
     public ResponseDTO<?> changePassword(Long userId, ChangePasswordRequest changePasswordRequest) {

--- a/src/main/java/com/example/yanolja/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/yanolja/domain/user/service/UserServiceImpl.java
@@ -1,15 +1,20 @@
 package com.example.yanolja.domain.user.service;
 
+
 import static com.example.yanolja.global.exception.ErrorCode.INVALID_EMAIL;
+import static com.example.yanolja.global.exception.ErrorCode.INVALID_PASSWORD;
 import static com.example.yanolja.global.exception.ErrorCode.INVALID_PHONENUMBER;
 import static com.example.yanolja.global.exception.ErrorCode.USER_ALREADY_REGISTERED;
+import static com.example.yanolja.global.exception.ErrorCode.USER_NOT_FOUND;
 
+import com.example.yanolja.domain.user.dto.ChangePasswordRequest;
 import com.example.yanolja.domain.user.dto.CreateUserRequest;
 import com.example.yanolja.domain.user.dto.CreateUserResponse;
 import com.example.yanolja.domain.user.dto.UpdateUserRequest;
 import com.example.yanolja.domain.user.entity.User;
 import com.example.yanolja.domain.user.exception.EmailDuplicateError;
 import com.example.yanolja.domain.user.exception.InvalidEmailException;
+import com.example.yanolja.domain.user.exception.InvalidPasswordException;
 import com.example.yanolja.domain.user.exception.InvalidPhonenumberError;
 import com.example.yanolja.domain.user.exception.UserNotFoundException;
 import com.example.yanolja.domain.user.repository.UserRepository;
@@ -20,6 +25,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,6 +35,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
     private static final String EMAIL_PATTERN =
         "^[_A-Za-z0-9-]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$";
     private static final String PHONENUMBER_REGEX =
@@ -83,7 +90,7 @@ public class UserServiceImpl implements UserService {
     public ResponseDTO<Object> deleteUser(Long userId) {
         try {
             User user = userRepository.findByUserId(userId)
-                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
             user.delete(LocalDateTime.now());
             userRepository.save(user);
             return ResponseDTO.res(HttpStatus.OK, "회원 탈퇴 처리 완료");
@@ -97,12 +104,27 @@ public class UserServiceImpl implements UserService {
     @Override
     public ResponseDTO<?> updateUser(Long userId, UpdateUserRequest updateUserRequest) {
         User user = userRepository.findById(userId)
-            .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다.")); // 적절한 예외 처리 필요
+            .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
 
         updateUserRequest.toEntity(user);
         userRepository.save(user);
 
         return ResponseDTO.res(HttpStatus.OK, "사용자 정보 업데이트 성공");
+    }
+
+    @Override
+    public ResponseDTO<?> changePassword(Long userId, ChangePasswordRequest changePasswordRequest) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
+
+        if (!passwordEncoder.matches(changePasswordRequest.getOldPassword(), user.getPassword())) {
+            throw new InvalidPasswordException(INVALID_PASSWORD);
+        }
+
+        user.setPassword(passwordEncoder.encode(changePasswordRequest.getNewPassword()));
+        userRepository.save(user);
+
+        return ResponseDTO.res(HttpStatus.OK, "비밀번호 변경 성공");
     }
 
 

--- a/src/main/java/com/example/yanolja/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/yanolja/domain/user/service/UserServiceImpl.java
@@ -138,6 +138,10 @@ public class UserServiceImpl implements UserService {
             throw new InvalidPasswordException(INVALID_PASSWORD);
         }
 
+        if (passwordEncoder.matches(changePasswordRequest.getNewPassword(), user.getPassword())) {
+            return ResponseDTO.res(HttpStatus.BAD_REQUEST, "새 비밀번호는 현재 비밀번호와 달라야 합니다.");
+        }
+
         user.setPassword(passwordEncoder.encode(changePasswordRequest.getNewPassword()));
         userRepository.save(user);
 

--- a/src/main/java/com/example/yanolja/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/yanolja/global/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     USER_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "이미 가입된 회원입니다."),
     INVALID_PHONENUMBER(HttpStatus.LENGTH_REQUIRED, "유효하지 않은 휴대폰 번호 형식"),
     INVALID_EMAIL(HttpStatus.PRECONDITION_FAILED, "유효하지 않은 이메일 형식"),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "잘못된 비밀번호입니다."),
 
     //Reservation
     RESERVATION_CONFLICT(HttpStatus.BAD_REQUEST, "예약하려는 시간대에 예약이 존재합니다."),

--- a/src/test/http/USER/myPage.http
+++ b/src/test/http/USER/myPage.http
@@ -1,0 +1,2 @@
+GET http://localhost:8080/user/mypage
+Authorization: token

--- a/src/test/http/USER/rePassword.http
+++ b/src/test/http/USER/rePassword.http
@@ -1,0 +1,9 @@
+### 비밀번호 변경
+PUT http://localhost:8080/user/repassword
+Content-Type: application/json
+Authorization: token
+
+{
+  "oldPassword": "newPassword",
+  "newPassword": "newPassword123"
+}

--- a/src/test/http/USER/update.http
+++ b/src/test/http/USER/update.http
@@ -1,0 +1,9 @@
+### 사용자 정보 수정
+PUT http://localhost:8080/user/update
+Authorization: token
+Content-Type: application/json
+
+{
+    "username": "변경 이름",
+    "phonenumber": "01012345678"
+}


### PR DESCRIPTION
## ⭐[Feature] 사용자 정보조회, 정보수정 기능 구현

### mypage 기능 구현
 - 로그인한 사용자의 email,name,phonenumber정보를 보여줍니다.

### 사용자 정보 수정 구현
 - mypage기능 일부인 로그인한 사용자의 username,phonenumber 정보를 변경하는 기능을 구현했습니다.

### 비밀번호 변경기능 정보수정 로직에서 분리
문제사항 :
 - 비밀번호,이름,휴대번호를 변경하는 로직이 한 곳에 있어 비밀번호를 변경하지 않았음에도 요청을 보내면 비밀번호가 새롭게 해싱되어 저장됨.
 - 보안 상 비밀번호 변경 로직을 분리하는 것이 옳다고 판단.
 
### 예외처리 개선
- InvalidPasswordException추가, UserNotFoundException리팩토링

### http파일 추가
- 구현한 기능 테스트를 위해 http파일을 추가하였습니다.

------------- 
#️⃣ Issue Link - #37 

- 비밀번호는 현재 비밀번호와 새로운 비밀번호를 받아 변경합니다.(현재 비밀번호 불일치시 변경 불가능)
- 정보수정 기능에서 username과 phonenumber 둘 다 변경이 되지 않으면 데이터베이스에 갱신되지 않도록 검증을 추가했지만, 둘 중 하나만 변경이 있을 경우 두 개의 정보가 모두 갱신됩니다. (userRepository.save(user) 사용해서 어쩔 수 없음...)

